### PR TITLE
feat(settings+security): add Settings screen with biometric auth toggle

### DIFF
--- a/iou-tracker/App.tsx
+++ b/iou-tracker/App.tsx
@@ -5,12 +5,14 @@ import Dashboard from './src/screens/Dashboard';
 import IOUScreen from './src/screens/IOUScreen';
 import UOMScreen from './src/screens/UOMScreen';
 import ContactsScreen from './src/screens/ContactsScreen';
+import SettingsScreen from './src/screens/SettingsScreen'; // NEW
 import { migrate } from './src/db/migrations';
 import { seedIfEmpty } from './src/db/seed';
 import { openDB } from './src/db/db';
 import { ThemeProvider, useAppTheme } from './src/theme/ThemeProvider';
+import AuthGate from './src/security/AuthGate'; // NEW
 
-type Screen = 'dashboard' | 'ious' | 'uoms' | 'contacts';
+type Screen = 'dashboard' | 'ious' | 'uoms' | 'contacts' | 'settings'; // NEW
 
 function AppContent() {
   const [currentScreen, setCurrentScreen] = useState<Screen>('dashboard');
@@ -33,12 +35,15 @@ function AppContent() {
         return <UOMScreen onBack={() => setCurrentScreen('dashboard')} />;
       case 'contacts':
         return <ContactsScreen onBack={() => setCurrentScreen('dashboard')} />;
+      case 'settings': // NEW
+        return <SettingsScreen onBack={() => setCurrentScreen('dashboard')} />;
       default:
         return (
           <Dashboard
             onNavigateToIOUs={() => setCurrentScreen('ious')}
             onNavigateToUOMs={() => setCurrentScreen('uoms')}
             onNavigateToContacts={() => setCurrentScreen('contacts')}
+            onNavigateToSettings={() => setCurrentScreen('settings')} // NEW (add a cog button in Dashboard to call this)
           />
         );
     }
@@ -60,7 +65,9 @@ export default function App() {
   return (
     <SafeAreaProvider>
       <ThemeProvider>
-        <AppContent />
+        <AuthGate>
+          <AppContent />
+        </AuthGate>
       </ThemeProvider>
     </SafeAreaProvider>
   );

--- a/iou-tracker/app.json
+++ b/iou-tracker/app.json
@@ -15,6 +15,7 @@
     "ios": {
       "supportsTablet": true,
       "infoPlist": {
+        "NSFaceIDUsageDescription": "Authenicate to secure your data.",
         "NSContactsUsageDescription": "This app needs access to contacts to help you quickly add people you owe money to or who owe you money."
       }
     },

--- a/iou-tracker/package-lock.json
+++ b/iou-tracker/package-lock.json
@@ -8,12 +8,14 @@
       "name": "iou-tracker",
       "version": "1.0.0",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "2.1.2",
         "@react-native-picker/picker": "^2.11.1",
         "decimal.js-light": "^2.5.1",
         "expo": "~53.0.20",
         "expo-contacts": "~14.2.5",
         "expo-crypto": "~14.1.5",
         "expo-file-system": "~18.1.11",
+        "expo-local-authentication": "~16.0.5",
         "expo-sqlite": "~15.2.14",
         "expo-status-bar": "~2.2.3",
         "expo-system-ui": "~5.0.10",
@@ -2298,6 +2300,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.1.2.tgz",
+      "integrity": "sha512-dvlNq4AlGWC+ehtH12p65+17V0Dx7IecOWl6WanF2ja38O1Dcjjvn7jVzkUHJ5oWkQBlyASurTPlTHgKXyYiow==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
     "node_modules/@react-native-picker/picker": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.11.1.tgz",
@@ -4273,6 +4287,18 @@
         "react": "*"
       }
     },
+    "node_modules/expo-local-authentication": {
+      "version": "16.0.5",
+      "resolved": "https://registry.npmjs.org/expo-local-authentication/-/expo-local-authentication-16.0.5.tgz",
+      "integrity": "sha512-JzrUssLBB5tr06ffbZJC074fru2mw6He3ALtwlRnrmL7svMJS0zvm6e5Gx5CSxfHf1DgneBVBnyRlmtWxQzY9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "2.1.14",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-2.1.14.tgz",
@@ -4842,6 +4868,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-wsl": {
@@ -5587,6 +5622,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/iou-tracker/package.json
+++ b/iou-tracker/package.json
@@ -23,7 +23,9 @@
     "react-native-paper": "^5.14.5",
     "react-native-safe-area-context": "5.4.0",
     "react-native-svg": "15.11.2",
-    "zustand": "^5.0.7"
+    "zustand": "^5.0.7",
+    "expo-local-authentication": "~16.0.5",
+    "@react-native-async-storage/async-storage": "2.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/iou-tracker/src/screens/Dashboard.tsx
+++ b/iou-tracker/src/screens/Dashboard.tsx
@@ -20,12 +20,14 @@ interface DashboardProps {
   onNavigateToIOUs?: () => void;
   onNavigateToUOMs?: () => void;
   onNavigateToContacts?: () => void;
+  onNavigateToSettings?: () => void; // NEW
 }
 
 export default function Dashboard({
   onNavigateToIOUs,
   onNavigateToUOMs,
   onNavigateToContacts,
+  onNavigateToSettings, // NEW
 }: DashboardProps) {
   const { dashboard, refresh } = useLedgerStore();
   const colors = useThemeColors();
@@ -78,8 +80,8 @@ export default function Dashboard({
   return (
     <ScrollView
       contentContainerStyle={{
-        paddingTop: insets.top + 8,           // safe area + breathing room
-        paddingBottom: 16 + insets.bottom,    // keep content/FAB off bottom edges
+        paddingTop: insets.top + 8,
+        paddingBottom: 16 + insets.bottom,
         paddingHorizontal: 16,
         gap: 12,
       }}
@@ -89,7 +91,7 @@ export default function Dashboard({
       <Card style={{ backgroundColor: colors.surface }}>
         <Card.Content style={{ paddingVertical: 0 }}>
           {/* IOU row */}
-          <TouchableRipple onPress={onNavigateToIOUs}>
+          <TouchableRipple onPress={onNavigateToIOUs} accessibilityLabel="Go to IOU list">
             <View
               style={{
                 paddingVertical: 16,
@@ -129,7 +131,7 @@ export default function Dashboard({
           <Divider />
 
           {/* UOM row */}
-          <TouchableRipple onPress={onNavigateToUOMs}>
+          <TouchableRipple onPress={onNavigateToUOMs} accessibilityLabel="Go to UOM list">
             <View
               style={{
                 paddingVertical: 16,
@@ -151,13 +153,13 @@ export default function Dashboard({
 
       {/* Stacked totals bar (no external chart deps) */}
       <ChartCard
-        title=''
+        title=""
         totalIOU={dashboard?.totalIOU ?? '0.00'}
         totalUOM={dashboard?.totalUOM ?? '0.00'}
       />
 
       {/* Contacts Navigation */}
-      <TouchableRipple onPress={onNavigateToContacts} borderless={false}>
+      <TouchableRipple onPress={onNavigateToContacts} borderless={false} accessibilityLabel="Manage Contacts">
         <Card style={{ backgroundColor: colors.surface }}>
           <Card.Content
             style={{
@@ -169,6 +171,24 @@ export default function Dashboard({
           >
             <Text variant="titleMedium" style={{ color: colors.textPrimary }}>
               Manage Contacts
+            </Text>
+          </Card.Content>
+        </Card>
+      </TouchableRipple>
+
+      {/* Settings Navigation (NEW) */}
+      <TouchableRipple onPress={onNavigateToSettings} borderless={false} accessibilityLabel="Open Settings">
+        <Card style={{ backgroundColor: colors.surface }}>
+          <Card.Content
+            style={{
+              height: 60,
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Text variant="titleMedium" style={{ color: colors.textPrimary }}>
+              Settings
             </Text>
           </Card.Content>
         </Card>

--- a/iou-tracker/src/screens/SettingsScreen.tsx
+++ b/iou-tracker/src/screens/SettingsScreen.tsx
@@ -1,0 +1,62 @@
+// src/screens/SettingsScreen.tsx
+import React from 'react';
+import { ScrollView, View } from 'react-native';
+import { Appbar, List, Switch, Text, RadioButton, Button, Divider } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useThemeColors } from '../theme/ThemeProvider';
+import { useSecurityStore } from '../store/securityStore';
+
+const OPTIONS = [
+  { label: '1 minute', ms: 60_000 },
+  { label: '5 minutes', ms: 5 * 60_000 },
+  { label: '15 minutes', ms: 15 * 60_000 },
+  { label: '1 hour', ms: 60 * 60_000 },
+];
+
+export default function SettingsScreen({ onBack }: { onBack?: () => void }) {
+  const colors = useThemeColors();
+  const insets = useSafeAreaInsets();
+  const { biometricsEnabled, sessionMs, setEnabled, setSessionMs, clearSession } = useSecurityStore();
+
+  return (
+    <>
+      <Appbar.Header statusBarHeight={insets.top}>
+        <Appbar.BackAction onPress={onBack} />
+        <Appbar.Content title="Settings" />
+      </Appbar.Header>
+
+      <ScrollView style={{ backgroundColor: colors.background }} contentContainerStyle={{ padding: 16, paddingBottom: 16 + insets.bottom }}>
+        <List.Section>
+          <List.Subheader>Security</List.Subheader>
+
+          <View style={{ backgroundColor: colors.surface, borderRadius: 8 }}>
+            <List.Item
+              title="Require biometric unlock"
+              description="Lock app on launch and when returning from background"
+              right={() => (
+                <Switch value={biometricsEnabled} onValueChange={(v) => setEnabled(v)} />
+              )}
+            />
+            <Divider />
+
+            <List.Item title="Grace period" description="Skip re-auth within this time window" />
+            <RadioButton.Group onValueChange={(v) => setSessionMs(Number(v))} value={String(sessionMs)}>
+              {OPTIONS.map((opt, idx) => (
+                <View key={opt.ms} style={{ paddingHorizontal: 16, paddingVertical: 8, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+                  <Text style={{ color: colors.textPrimary }}>{opt.label}</Text>
+                  <RadioButton value={String(opt.ms)} />
+                </View>
+              ))}
+            </RadioButton.Group>
+
+            <View style={{ padding: 16 }}>
+              <Button mode="outlined" onPress={() => clearSession()}>
+                Lock now
+              </Button>
+            </View>
+          </View>
+        </List.Section>
+      </ScrollView>
+    </>
+  );
+}

--- a/iou-tracker/src/security/AuthGate.tsx
+++ b/iou-tracker/src/security/AuthGate.tsx
@@ -1,0 +1,70 @@
+// src/security/AuthGate.tsx
+import React, { useEffect, useRef, useState } from 'react';
+import { AppState, View, ActivityIndicator } from 'react-native';
+import { Text, Button } from 'react-native-paper';
+import { authenticate } from './biometrics';
+import { useThemeColors } from '../theme/ThemeProvider';
+import { useSecurityStore } from '../store/securityStore';
+
+export default function AuthGate({ children }: { children: React.ReactNode }) {
+  const colors = useThemeColors();
+  const { biometricsEnabled, sessionMs, lastAuthAt, markAuthed } = useSecurityStore();
+  const [locked, setLocked] = useState<boolean>(biometricsEnabled);
+  const appState = useRef(AppState.currentState);
+
+  const tryAuth = async (prompt?: string) => {
+    const res = await authenticate(prompt);
+    if (res.ok) {
+      markAuthed();
+      setLocked(false);
+    } else {
+      setLocked(true);
+    }
+  };
+
+  // On mount: only lock if enabled & session expired
+  useEffect(() => {
+    if (!biometricsEnabled) {
+      setLocked(false);
+      return;
+    }
+    const fresh = lastAuthAt && Date.now() - lastAuthAt < sessionMs;
+    if (fresh) setLocked(false);
+    else {
+      setLocked(true);
+      tryAuth('Authenticate to continue');
+    }
+  }, [biometricsEnabled, sessionMs, lastAuthAt]);
+
+  // On resume: if enabled and session expired, lock and prompt
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (state) => {
+      const prev = appState.current;
+      appState.current = state;
+      if (!biometricsEnabled) return;
+
+      if ((prev === 'background' || prev === 'inactive') && state === 'active') {
+        const expired = !lastAuthAt || Date.now() - lastAuthAt >= sessionMs;
+        if (expired) {
+          setLocked(true);
+          tryAuth('Re-authenticate');
+        }
+      }
+    });
+    return () => sub.remove();
+  }, [biometricsEnabled, sessionMs, lastAuthAt]);
+
+  if (!biometricsEnabled || !locked) return <>{children}</>;
+
+  return (
+    <View style={{ flex: 1, backgroundColor: colors.background, alignItems: 'center', justifyContent: 'center', padding: 24 }}>
+      <ActivityIndicator />
+      <Text style={{ color: colors.textPrimary, marginTop: 16, marginBottom: 8 }}>
+        Locked — biometric authentication required
+      </Text>
+      <Button mode="contained" onPress={() => tryAuth()} icon="fingerprint">
+        Unlock
+      </Button>
+    </View>
+  );
+}

--- a/iou-tracker/src/security/AuthGate.tsx
+++ b/iou-tracker/src/security/AuthGate.tsx
@@ -9,39 +9,51 @@ import { useSecurityStore } from '../store/securityStore';
 export default function AuthGate({ children }: { children: React.ReactNode }) {
   const colors = useThemeColors();
   const { biometricsEnabled, sessionMs, lastAuthAt, markAuthed } = useSecurityStore();
+  const hasHydrated = useSecurityStore.persist.hasHydrated();
   const [locked, setLocked] = useState<boolean>(biometricsEnabled);
+  const [authing, setAuthing] = useState(false);
   const appState = useRef(AppState.currentState);
 
   const tryAuth = async (prompt?: string) => {
-    const res = await authenticate(prompt);
-    if (res.ok) {
-      markAuthed();
-      setLocked(false);
-    } else {
+    if (authing) return;
+    setAuthing(true);
+    try {
+      const res = await authenticate(prompt);
+      if (res.ok) {
+        markAuthed();
+        setLocked(false);
+      } else {
+        setLocked(true);
+      }
+    } catch (err) {
       setLocked(true);
+    } finally {
+      setAuthing(false);
     }
   };
 
   // On mount: only lock if enabled & session expired
   useEffect(() => {
+    if (!hasHydrated) return; // Wait for store hydration
     if (!biometricsEnabled) {
       setLocked(false);
       return;
     }
-    const fresh = lastAuthAt && Date.now() - lastAuthAt < sessionMs;
-    if (fresh) setLocked(false);
-    else {
+    const fresh = Boolean(lastAuthAt && Date.now() - lastAuthAt < sessionMs);
+    if (fresh) {
+      setLocked(false);
+    } else {
       setLocked(true);
       tryAuth('Authenticate to continue');
     }
-  }, [biometricsEnabled, sessionMs, lastAuthAt]);
+  }, [biometricsEnabled, sessionMs, lastAuthAt, hasHydrated]);
 
   // On resume: if enabled and session expired, lock and prompt
   useEffect(() => {
     const sub = AppState.addEventListener('change', (state) => {
       const prev = appState.current;
       appState.current = state;
-      if (!biometricsEnabled) return;
+      if (!biometricsEnabled || !hasHydrated) return;
 
       if ((prev === 'background' || prev === 'inactive') && state === 'active') {
         const expired = !lastAuthAt || Date.now() - lastAuthAt >= sessionMs;
@@ -52,18 +64,31 @@ export default function AuthGate({ children }: { children: React.ReactNode }) {
       }
     });
     return () => sub.remove();
-  }, [biometricsEnabled, sessionMs, lastAuthAt]);
+  }, [biometricsEnabled, sessionMs, lastAuthAt, hasHydrated]);
 
   if (!biometricsEnabled || !locked) return <>{children}</>;
 
   return (
-    <View style={{ flex: 1, backgroundColor: colors.background, alignItems: 'center', justifyContent: 'center', padding: 24 }}>
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: colors.background,
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 24,
+      }}
+    >
       <ActivityIndicator />
       <Text style={{ color: colors.textPrimary, marginTop: 16, marginBottom: 8 }}>
         Locked — biometric authentication required
       </Text>
-      <Button mode="contained" onPress={() => tryAuth()} icon="fingerprint">
-        Unlock
+      <Button
+        mode="contained"
+        onPress={() => tryAuth()}
+        icon="fingerprint"
+        disabled={authing}
+      >
+        {authing ? 'Authenticating…' : 'Unlock'}
       </Button>
     </View>
   );

--- a/iou-tracker/src/security/biometrics.ts
+++ b/iou-tracker/src/security/biometrics.ts
@@ -2,21 +2,41 @@
 import * as LocalAuthentication from 'expo-local-authentication';
 
 export async function authenticate(prompt = 'Unlock') {
-  const hasHW = await LocalAuthentication.hasHardwareAsync();
-  const enrolled = hasHW && (await LocalAuthentication.isEnrolledAsync());
-  if (!hasHW) return { ok: false, error: 'Biometrics not available' };
-  if (!enrolled) return { ok: false, error: 'No biometrics enrolled' };
+  try {
+    const hasHW = await LocalAuthentication.hasHardwareAsync();
+    if (!hasHW) {
+      return { ok: false, error: 'Biometrics not available' };
+    }
 
-  const res = await LocalAuthentication.authenticateAsync({
-    promptMessage: prompt,
-    cancelLabel: 'Cancel',
-    disableDeviceFallback: false, // allow PIN/passcode fallback
-    requireConfirmation: false,
-  });
+    const isEnrolled = await LocalAuthentication.isEnrolledAsync();
+    if (!isEnrolled) {
+      return { ok: false, error: 'No biometrics enrolled' };
+    }
 
-  if (res.success) return { ok: true as const };
-  if (['user_cancel', 'system_cancel', 'app_cancelled'].includes(res.error ?? '')) {
-    return { ok: false as const, cancelled: true };
+    // Optional: stronger check using enrolled level (can be uncommented if needed)
+    // const enrolledLevel = await LocalAuthentication.getEnrolledLevelAsync();
+    // if (enrolledLevel < LocalAuthentication.SecurityLevel.BIOMETRIC) {
+    //   return { ok: false, error: 'Insufficient biometric security level' };
+    // }
+
+    const res = await LocalAuthentication.authenticateAsync({
+      promptMessage: prompt,
+      cancelLabel: 'Cancel',
+      disableDeviceFallback: false,
+      requireConfirmation: false,
+    });
+
+    if (res.success) {
+      return { ok: true as const };
+    }
+
+    const cancellationCodes = ['user_cancel', 'system_cancel', 'app_cancel'];
+    if (cancellationCodes.includes(res.error ?? '')) {
+      return { ok: false as const, cancelled: true };
+    }
+
+    return { ok: false as const, error: res.error ?? 'Authentication failed' };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message || 'Unexpected error' };
   }
-  return { ok: false as const, error: res.error ?? 'Authentication failed' };
 }

--- a/iou-tracker/src/security/biometrics.ts
+++ b/iou-tracker/src/security/biometrics.ts
@@ -1,0 +1,22 @@
+// src/security/biometrics.ts
+import * as LocalAuthentication from 'expo-local-authentication';
+
+export async function authenticate(prompt = 'Unlock') {
+  const hasHW = await LocalAuthentication.hasHardwareAsync();
+  const enrolled = hasHW && (await LocalAuthentication.isEnrolledAsync());
+  if (!hasHW) return { ok: false, error: 'Biometrics not available' };
+  if (!enrolled) return { ok: false, error: 'No biometrics enrolled' };
+
+  const res = await LocalAuthentication.authenticateAsync({
+    promptMessage: prompt,
+    cancelLabel: 'Cancel',
+    disableDeviceFallback: false, // allow PIN/passcode fallback
+    requireConfirmation: false,
+  });
+
+  if (res.success) return { ok: true as const };
+  if (['user_cancel', 'system_cancel', 'app_cancelled'].includes(res.error ?? '')) {
+    return { ok: false as const, cancelled: true };
+  }
+  return { ok: false as const, error: res.error ?? 'Authentication failed' };
+}

--- a/iou-tracker/src/store/securityStore.ts
+++ b/iou-tracker/src/store/securityStore.ts
@@ -6,6 +6,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 /**
  * Persist version history
  * v1: add `hydrated` runtime flag, default biometricsEnabled=false
+ * v2: add `setHydrated` action to API
  */
 export type SecurityState = {
   biometricsEnabled: boolean;
@@ -16,12 +17,13 @@ export type SecurityState = {
   setSessionMs: (ms: number) => void;
   markAuthed: () => void;
   clearSession: () => void;
+  setHydrated: (v: boolean) => void;
 };
 
 export const useSecurityStore = create<SecurityState>()(
   persist(
     (set, get) => ({
-      biometricsEnabled: false, // default false to avoid first-launch lockout
+      biometricsEnabled: false, // avoid first-launch lockout
       sessionMs: 5 * 60 * 1000,
       lastAuthAt: null,
       hydrated: false,
@@ -29,69 +31,30 @@ export const useSecurityStore = create<SecurityState>()(
       setSessionMs: (ms) => set({ sessionMs: ms }),
       markAuthed: () => set({ lastAuthAt: Date.now() }),
       clearSession: () => set({ lastAuthAt: null }),
+      setHydrated: (v) => set({ hydrated: v }),
     }),
     {
       name: 'security-settings',
-      version: 1,
+      version: 2,
       storage: createJSONStorage(() => AsyncStorage),
       partialize: (s) => ({
         biometricsEnabled: s.biometricsEnabled,
         sessionMs: s.sessionMs,
         lastAuthAt: s.lastAuthAt,
-        // `hydrated` is runtime-only; do not persist
+        // hydrated & setters are runtime-only
       }),
       migrate: async (persisted, fromVersion) => {
-        // Ensure sane defaults if coming from older versions
         const p = (persisted as Partial<SecurityState>) ?? {};
         return {
           biometricsEnabled: p.biometricsEnabled ?? false,
           sessionMs: p.sessionMs ?? 5 * 60 * 1000,
           lastAuthAt: p.lastAuthAt ?? null,
-          // hydrated is handled by onRehydrateStorage
-          hydrated: false,
-          setEnabled: () => {},
-          setSessionMs: () => {},
-          markAuthed: () => {},
-          clearSession: () => {},
         } as unknown as SecurityState;
       },
-      onRehydrateStorage: () => (state, error) => {
-        // Mark store ready only after rehydration completes
-        // Why: prevents premature gating using default state
-        state?.setEnabled &&
-          // Rebind setters (migrate returns no-op placeholders); ensure we keep runtime methods
-          Object.assign(state, {
-            setEnabled: (v: boolean) => useSecurityStore.setState({ biometricsEnabled: v }),
-            setSessionMs: (ms: number) => useSecurityStore.setState({ sessionMs: ms }),
-            markAuthed: () => useSecurityStore.setState({ lastAuthAt: Date.now() }),
-            clearSession: () => useSecurityStore.setState({ lastAuthAt: null }),
-          });
-        useSecurityStore.setState({ hydrated: true });
+      onRehydrateStorage: () => () => {
+        // mark store ready only after rehydration completes
+        useSecurityStore.getState().setHydrated(true);
       },
     }
   )
 );
-
-// ----------------------------------------------------------------------------
-// Example usage: update AuthGate to respect hydration before enforcing lock
-// ----------------------------------------------------------------------------
-// src/components/AuthGate.tsx
-// import React from 'react';
-// import { useSecurityStore } from '@/store/securityStore';
-//
-// type Props = { children: React.ReactNode; LockScreen: React.ComponentType; Loading?: React.ComponentType };
-//
-// export default function AuthGate({ children, LockScreen, Loading }: Props) {
-//   const { hydrated, biometricsEnabled, lastAuthAt, sessionMs } = useSecurityStore();
-//
-//   if (!hydrated) {
-//     return Loading ? <Loading /> : null; // render nothing or a spinner until ready
-//   }
-//
-//   const now = Date.now();
-//   const inSession = lastAuthAt != null && now - lastAuthAt <= sessionMs;
-//   const locked = biometricsEnabled && !inSession;
-//
-//   if (locked) return <LockScreen />;
-//   return <>{children}</>;
-// }

--- a/iou-tracker/src/store/securityStore.ts
+++ b/iou-tracker/src/store/securityStore.ts
@@ -20,6 +20,8 @@ export type SecurityState = {
   setHydrated: (v: boolean) => void;
 };
 
+const MAX_SESSION_MS = 86_400_000; // 24 hours
+
 export const useSecurityStore = create<SecurityState>()(
   persist(
     (set, get) => ({
@@ -28,7 +30,12 @@ export const useSecurityStore = create<SecurityState>()(
       lastAuthAt: null,
       hydrated: false,
       setEnabled: (v) => set({ biometricsEnabled: v }),
-      setSessionMs: (ms) => set({ sessionMs: ms }),
+      setSessionMs: (ms) => {
+        // why: prevent negative/huge values that break gating logic
+        const value = Number.isFinite(ms) ? ms : 0;
+        const clamped = Math.max(0, Math.min(value, MAX_SESSION_MS));
+        set({ sessionMs: clamped });
+      },
       markAuthed: () => set({ lastAuthAt: Date.now() }),
       clearSession: () => set({ lastAuthAt: null }),
       setHydrated: (v) => set({ hydrated: v }),

--- a/iou-tracker/src/store/securityStore.ts
+++ b/iou-tracker/src/store/securityStore.ts
@@ -45,11 +45,13 @@ export const useSecurityStore = create<SecurityState>()(
       }),
       migrate: async (persisted, fromVersion) => {
         const p = (persisted as Partial<SecurityState>) ?? {};
-        return {
+        // Return a partial slice only for persisted keys; runtime fields are omitted
+        const next: Partial<SecurityState> = {
           biometricsEnabled: p.biometricsEnabled ?? false,
           sessionMs: p.sessionMs ?? 5 * 60 * 1000,
           lastAuthAt: p.lastAuthAt ?? null,
-        } as unknown as SecurityState;
+        };
+        return next;
       },
       onRehydrateStorage: () => () => {
         // mark store ready only after rehydration completes

--- a/iou-tracker/src/store/securityStore.ts
+++ b/iou-tracker/src/store/securityStore.ts
@@ -3,10 +3,15 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-type SecurityState = {
+/**
+ * Persist version history
+ * v1: add `hydrated` runtime flag, default biometricsEnabled=false
+ */
+export type SecurityState = {
   biometricsEnabled: boolean;
-  sessionMs: number;           // grace period
-  lastAuthAt: number | null;   // epoch ms of last success
+  sessionMs: number; // grace period
+  lastAuthAt: number | null; // epoch ms of last success
+  hydrated: boolean; // true after persist rehydration completes
   setEnabled: (v: boolean) => void;
   setSessionMs: (ms: number) => void;
   markAuthed: () => void;
@@ -15,10 +20,11 @@ type SecurityState = {
 
 export const useSecurityStore = create<SecurityState>()(
   persist(
-    (set) => ({
-      biometricsEnabled: true,
-      sessionMs: 5 * 60 * 1000, // default 5 min
+    (set, get) => ({
+      biometricsEnabled: false, // default false to avoid first-launch lockout
+      sessionMs: 5 * 60 * 1000,
       lastAuthAt: null,
+      hydrated: false,
       setEnabled: (v) => set({ biometricsEnabled: v }),
       setSessionMs: (ms) => set({ sessionMs: ms }),
       markAuthed: () => set({ lastAuthAt: Date.now() }),
@@ -26,12 +32,66 @@ export const useSecurityStore = create<SecurityState>()(
     }),
     {
       name: 'security-settings',
+      version: 1,
       storage: createJSONStorage(() => AsyncStorage),
       partialize: (s) => ({
         biometricsEnabled: s.biometricsEnabled,
         sessionMs: s.sessionMs,
         lastAuthAt: s.lastAuthAt,
+        // `hydrated` is runtime-only; do not persist
       }),
+      migrate: async (persisted, fromVersion) => {
+        // Ensure sane defaults if coming from older versions
+        const p = (persisted as Partial<SecurityState>) ?? {};
+        return {
+          biometricsEnabled: p.biometricsEnabled ?? false,
+          sessionMs: p.sessionMs ?? 5 * 60 * 1000,
+          lastAuthAt: p.lastAuthAt ?? null,
+          // hydrated is handled by onRehydrateStorage
+          hydrated: false,
+          setEnabled: () => {},
+          setSessionMs: () => {},
+          markAuthed: () => {},
+          clearSession: () => {},
+        } as unknown as SecurityState;
+      },
+      onRehydrateStorage: () => (state, error) => {
+        // Mark store ready only after rehydration completes
+        // Why: prevents premature gating using default state
+        state?.setEnabled &&
+          // Rebind setters (migrate returns no-op placeholders); ensure we keep runtime methods
+          Object.assign(state, {
+            setEnabled: (v: boolean) => useSecurityStore.setState({ biometricsEnabled: v }),
+            setSessionMs: (ms: number) => useSecurityStore.setState({ sessionMs: ms }),
+            markAuthed: () => useSecurityStore.setState({ lastAuthAt: Date.now() }),
+            clearSession: () => useSecurityStore.setState({ lastAuthAt: null }),
+          });
+        useSecurityStore.setState({ hydrated: true });
+      },
     }
   )
 );
+
+// ----------------------------------------------------------------------------
+// Example usage: update AuthGate to respect hydration before enforcing lock
+// ----------------------------------------------------------------------------
+// src/components/AuthGate.tsx
+// import React from 'react';
+// import { useSecurityStore } from '@/store/securityStore';
+//
+// type Props = { children: React.ReactNode; LockScreen: React.ComponentType; Loading?: React.ComponentType };
+//
+// export default function AuthGate({ children, LockScreen, Loading }: Props) {
+//   const { hydrated, biometricsEnabled, lastAuthAt, sessionMs } = useSecurityStore();
+//
+//   if (!hydrated) {
+//     return Loading ? <Loading /> : null; // render nothing or a spinner until ready
+//   }
+//
+//   const now = Date.now();
+//   const inSession = lastAuthAt != null && now - lastAuthAt <= sessionMs;
+//   const locked = biometricsEnabled && !inSession;
+//
+//   if (locked) return <LockScreen />;
+//   return <>{children}</>;
+// }

--- a/iou-tracker/src/store/securityStore.ts
+++ b/iou-tracker/src/store/securityStore.ts
@@ -1,0 +1,37 @@
+// src/store/securityStore.ts
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+type SecurityState = {
+  biometricsEnabled: boolean;
+  sessionMs: number;           // grace period
+  lastAuthAt: number | null;   // epoch ms of last success
+  setEnabled: (v: boolean) => void;
+  setSessionMs: (ms: number) => void;
+  markAuthed: () => void;
+  clearSession: () => void;
+};
+
+export const useSecurityStore = create<SecurityState>()(
+  persist(
+    (set) => ({
+      biometricsEnabled: true,
+      sessionMs: 5 * 60 * 1000, // default 5 min
+      lastAuthAt: null,
+      setEnabled: (v) => set({ biometricsEnabled: v }),
+      setSessionMs: (ms) => set({ sessionMs: ms }),
+      markAuthed: () => set({ lastAuthAt: Date.now() }),
+      clearSession: () => set({ lastAuthAt: null }),
+    }),
+    {
+      name: 'security-settings',
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (s) => ({
+        biometricsEnabled: s.biometricsEnabled,
+        sessionMs: s.sessionMs,
+        lastAuthAt: s.lastAuthAt,
+      }),
+    }
+  )
+);


### PR DESCRIPTION
- Added Settings navigation link to Dashboard
- Created Settings screen with option to enable/disable biometric authentication
- Integrated expo-local-authentication for FaceID/TouchID/Fingerprint support
- Wrapped App in biometric check when security setting is enabled
- Persisted biometric preference in store for consistent behavior across sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Settings screen with options for enabling biometric unlock, setting a session grace period, and manually locking the app.
  * Added biometric authentication support, allowing users to secure the app with Face ID or similar technologies.
  * Implemented an authentication gate that locks the app on launch or when returning from the background if biometric security is enabled.
  * Added a "Settings" navigation card to the dashboard for easy access.
  * Improved accessibility with labels for navigation elements.

* **Chores**
  * Added new dependencies for biometric authentication and persistent storage.
  * Updated app configuration to include Face ID usage description for iOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->